### PR TITLE
DPL-083 Tag Docker images with the release version, not the branch

### DIFF
--- a/.github/workflows/automated_release.yml
+++ b/.github/workflows/automated_release.yml
@@ -63,4 +63,9 @@ jobs:
       - name: Publish the image with image tag being either develop/master
         run: >-
           docker push
-          docker.pkg.github.com/${IMAGE_NAME}:${BRANCH_NAME}
+          docker.pkg.github.com/${IMAGE_NAME}:${{ env.RELEASE_VERSION }}
+
+      - name: Remove the oldest package
+        uses: actions/delete-package-versions@v1
+        with:
+          package-name: "${{ github.event.repository.name }}"


### PR DESCRIPTION
Part of https://github.com/sanger/deployment/issues/71

Ansible looks for a Docker image tagged the same as the release, but we're tagging with the branch name.  This changes that and makes sure we don't end up with hundreds of images in GitHub Packages.