### PR TITLE
Y24-036: Fixed previous stable images being deleted

### DIFF
--- a/.github/workflows/automated_release.yml
+++ b/.github/workflows/automated_release.yml
@@ -75,11 +75,10 @@ jobs:
         uses: snok/container-retention-policy@v2
         with:
           image-names: ${{ github.event.repository.name }}/*
-          cut-off: Two weeks ago UTC
+          cut-off: Four months ago UTC
           timestamp-to-use: updated_at
           account-type: org
           org-name: sanger
-          keep-at-least: 0
+          keep-at-least: 5
           skip-tags: latest, *[!develop] # This will DELETE any images where the tag contains ANY characters in "develop"
-          dry-run: true
           token: ${{ secrets.REMOVE_OLD_IMAGES }}


### PR DESCRIPTION
Closes https://github.com/sanger/General-Backlog-Items/issues/378

#### Changes proposed in this pull request

- The workflow configuration file was changed so that all images marked with the develop tag (older than four months) will be deleted while previous stable releases will be kept regardless.

> The previous PRs were dry runs, this action will now run properly.

#### Instructions for Reviewers

_[All PRs] - Confirm PR template filled_  
_[Feature Branches] - Review code_  
_[Production Merges to `main`]_  
 &nbsp; &nbsp; \- _Check story numbers included_  
 &nbsp; &nbsp; \- _Check for debug code_  
 &nbsp; &nbsp; \- _Check version_  
