### PR TITLE
Y24-254 - CUPSD wait fix

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -2,13 +2,11 @@
 mkdir /etc/cups/
 echo "ServerName $CUPSD_SERVER_NAME" > /etc/cups/client.conf
 TIMEOUT=120
-CUPSPORT=631
-CUPSHOST=cupsd
 
 if [[ $CUPSD_UPDATE == "true" ]]
 then
     echo "-> Waiting for cups to become available"
-    bash ./wait_for_connection.sh "${CUPSHOST}" "${CUPSPORT}" "${TIMEOUT}"
+    bash ./wait_for_cups.sh "${TIMEOUT}"
     echo "-> Running printers rake task"
     bundle exec rails printers:create
     echo "-> Printers rake task complete"

--- a/wait_for_cups.sh
+++ b/wait_for_cups.sh
@@ -1,23 +1,20 @@
 #!/usr/bin/env bash
 
 #
-# This script waits TIMEOUT seconds for connection to HOST:PORT
-# to be stablished and exit with 0 if success or 1 if error
+# This script waits TIMEOUT seconds for connection to cups
+# to be established and exit with 0 if success or 1 if error
 set -o pipefail
 set -o nounset
 
-HOST=$1
-PORT=$2
-TIMEOUT=$3
+TIMEOUT=$1
 
 TIMEOUT_END=$(($(date +%s) + TIMEOUT))
 result=1
 while [ $result -ne 0 ]; do
-  echo "Waiting for connection to ${HOST}:${PORT}..."
-  wget --spider "${HOST}:${PORT}"
-  result=$?
+  echo "Waiting for connection to cups..."
+  result="`lpstat -r | grep 'scheduler is not running' | wc -l`"
   if [ $result -eq 0 ]; then
-    echo "Connected to ${HOST}:${PORT}."
+    echo "Connected to cups"
     exit 0
   else
     if [ $(date +%s) -ge $TIMEOUT_END ]; then

--- a/wait_for_cups.sh
+++ b/wait_for_cups.sh
@@ -10,10 +10,10 @@ TIMEOUT=$1
 
 TIMEOUT_END=$(($(date +%s) + TIMEOUT))
 result=1
-while [ $result -ne 0 ]; do
+while [ $result -ne 1 ]; do
   echo "Waiting for connection to cups..."
-  result="`lpstat -r | grep 'scheduler is not running' | wc -l`"
-  if [ $result -eq 0 ]; then
+  result="`lpstat -r | grep 'scheduler is running' | wc -l`"
+  if [ $result -eq 1 ]; then
     echo "Connected to cups"
     exit 0
   else

--- a/wait_for_cups.sh
+++ b/wait_for_cups.sh
@@ -9,7 +9,7 @@ set -o nounset
 TIMEOUT=$1
 
 TIMEOUT_END=$(($(date +%s) + TIMEOUT))
-result=1
+result=0
 while [ $result -ne 1 ]; do
   echo "Waiting for connection to cups..."
   result="`lpstat -r | grep 'scheduler is running' | wc -l`"


### PR DESCRIPTION
Closes #471

#### Changes proposed in this pull request

- Updates wait_for_connection script to be cups-scheduler specific.
- Utilising lpstat command we can be sure cups service is ready to receive printers and not just that the web api is responding.
